### PR TITLE
Adding support for specifying a Proxy to use for the connection

### DIFF
--- a/sdk/src/main/java/org/ovirt/engine/sdk4/ConnectionBuilder.java
+++ b/sdk/src/main/java/org/ovirt/engine/sdk4/ConnectionBuilder.java
@@ -43,6 +43,8 @@ public abstract class ConnectionBuilder {
     protected String user;
     protected String password;
     protected String token;
+
+    protected ProxyInfo proxyInfo;
     protected boolean insecure = false;
     protected boolean kerberos = false;
     protected int timeout = 0;
@@ -207,6 +209,16 @@ public abstract class ConnectionBuilder {
      */
     public ConnectionBuilder ssoUrl(String ssoUrl) {
         this.ssoUrl = ssoUrl;
+        return this;
+    }
+
+    /**
+     * Set proxy information if using a Proxy
+     * @param proxyInfo
+     * @return
+     */
+    public ConnectionBuilder proxy(ProxyInfo proxyInfo) {
+        this.proxyInfo = proxyInfo;
         return this;
     }
 

--- a/sdk/src/main/java/org/ovirt/engine/sdk4/ProxyInfo.java
+++ b/sdk/src/main/java/org/ovirt/engine/sdk4/ProxyInfo.java
@@ -1,0 +1,85 @@
+package org.ovirt.engine.sdk4;
+
+public class ProxyInfo {
+	protected String host;
+	private Integer proxyPort;
+	protected String user;
+	protected String password;
+	private String proxyDomain;
+	private String proxyWorkstation;
+
+	private ProxyType proxyType;
+
+
+	public ProxyInfo(String host, Integer proxyPort, String user, String password, String proxyDomain, ProxyType proxyType) {
+		this.host = host;
+		this.proxyPort = proxyPort;
+		this.user = user;
+		this.password = password;
+		this.proxyDomain = proxyDomain;
+		this.proxyType = proxyType;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public Integer getProxyPort() {
+		return proxyPort;
+	}
+
+	public void setProxyPort(Integer proxyPort) {
+		this.proxyPort = proxyPort;
+	}
+
+	public String getProxyDomain() {
+		return proxyDomain;
+	}
+
+	public void setProxyDomain(String proxyDomain) {
+		this.proxyDomain = proxyDomain;
+	}
+
+	public ProxyType getProxyType() {
+		return proxyType;
+	}
+
+	public void setProxyType(ProxyType proxyType) {
+		this.proxyType = proxyType;
+	}
+
+	public String getProxyWorkstation() {
+		return proxyWorkstation;
+	}
+
+	public void setProxyWorkstation(String proxyWorkstation) {
+		this.proxyWorkstation = proxyWorkstation;
+	}
+
+
+	//create an enum for proxy type
+	public enum ProxyType {
+		HTTP, SOCKS
+	}
+}

--- a/sdk/src/main/java/org/ovirt/engine/sdk4/internal/HttpConnection.java
+++ b/sdk/src/main/java/org/ovirt/engine/sdk4/internal/HttpConnection.java
@@ -73,6 +73,7 @@ public class HttpConnection implements Connection {
     private String ssoTokenName = null;
     private String ssoUrl = null;
     private String ssoRevokeUrl = null;
+
     private Map<String, String> headers = null;
 
 


### PR DESCRIPTION
This library does not allow you to specify a Proxy for the connection. This adds support for passing Proxy Information for both SOCKS or HTTP proxies