### PR TITLE
build: Bump undertow version to latest release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.
     <jackson.version>2.18.2</jackson.version>
     <junit.version>4.13.1</junit.version>
     <slf4j.version>1.7.7</slf4j.version>
-    <undertow.version>2.2.25.Final</undertow.version>
+    <undertow.version>2.4.1.Final</undertow.version>
     <weld-se.version>3.1.9.Final</weld-se.version>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
     <maven-source-plugin.version>2.4</maven-source-plugin.version>


### PR DESCRIPTION
Previous version was from 3 years ago.
Bumps undertow-core from 2.2.25.Final to 2.4.1.Final. 
[Release notes](https://github.com/undertow-io/undertow/releases/tag/2.4.1.Final)
replaces https://github.com/oVirt/ovirt-engine-sdk-java/pull/39