### PR TITLE
build: bump commons-io version from 2.7 to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ limitations under the License.
 
     <!-- Dependencies -->
     <commons-cli.version>1.3</commons-cli.version>
-    <commons-io.version>2.7</commons-io.version>
+    <commons-io.version>2.22.0</commons-io.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.14</httpcore.version>
     <jackson.version>2.18.2</jackson.version>


### PR DESCRIPTION
Last version was from 6 years ago, multiple vulnerabilities were found since then.
Bump to latest available release to avoid unneeded bumps in between.

This supersedes https://github.com/oVirt/ovirt-engine-sdk-java/pull/46